### PR TITLE
Add new max function to series

### DIFF
--- a/series_functions/max.js
+++ b/series_functions/max.js
@@ -1,0 +1,24 @@
+var reduce = require('../lib/reduce.js');
+
+var Chainable = require('../lib/classes/chainable');
+module.exports = new Chainable('max', {
+  args: [
+    {
+      name: 'inputSeries',
+      types: ['seriesList']
+    },
+    {
+      name: 'value',
+      types: ['seriesList', 'number'],
+      help: 'Number, series to max with the input series. If passing a seriesList it must contain exactly 1 series.'
+
+    }
+
+  ],
+  help: 'Maximum values of one or more series in a seriesList to each position, in each series, of the input seriesList',
+  fn: function maxFn(args) {
+    return reduce(args, function (a, b) {
+      return Math.max(a, b);
+    });
+  }
+});


### PR DESCRIPTION
This function computes the max of current series against number or
other serie.

It can be used to avoid to display negative derivative value:
```
 .es(metric='avg:counter').derivative().max(0)
```

This fixes #40.