### PR TITLE
Follow API conventions

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -46,13 +46,15 @@ require('ui/routes')
   });
 
 app.controller('timelion', function (
-  $scope, $http, timefilter, AppState, courier, $route, $routeParams, kbnUrl, Notifier, config, $timeout, Private) {
+  $scope, timefilter, AppState, courier, $route, $routeParams, kbnUrl, Notifier, config, $timeout, Private) {
   timefilter.enabled = true;
   var notify = new Notifier({
     location: 'Timelion'
   });
 
   var timezone = Private(require('plugins/timelion/services/timezone'))();
+  var api = Private(require('plugins/timelion/services/api'));
+
   var defaultExpression = '.es(*)';
   var savedSheet = $route.current.locals.savedSheet;
   var blankSheet = [defaultExpression];
@@ -151,7 +153,7 @@ app.controller('timelion', function (
     $scope.state.save();
     $scope.running = true;
 
-    $http.post('timelion/run', {
+    api.run({
       sheet: $scope.state.sheet,
       time: _.extend(timefilter.time, {
         interval: getInterval($scope.state),

--- a/public/directives/docs.js
+++ b/public/directives/docs.js
@@ -4,11 +4,13 @@ define(function (require) {
   var _ = require('lodash');
   var moment = require('moment');
 
-  app.directive('timelionDocs', function (config, $http) {
+  app.directive('timelionDocs', function () {
     return {
       restrict: 'E',
       template: html,
-      controller: function ($scope, config) {
+      controller: function ($scope, config, Private) {
+        var api = Private(require('../services/api'));
+
         $scope.section = config.get('timelion:showTutorial', true) ? 'tutorial' : 'functions';
         $scope.page = 1;
         $scope.functions = {
@@ -25,7 +27,7 @@ define(function (require) {
         };
 
         function getFunctions() {
-          return $http.get('timelion/functions').then(function (resp) {
+          return api.functions().then(function (resp) {
             $scope.functions.list = resp.data;
           });
         }
@@ -37,7 +39,7 @@ define(function (require) {
         };
 
         function checkElasticsearch() {
-          return $http.get('timelion/validate/es').then(function (resp) {
+          return api.validateWithEs().then(function (resp) {
             if (resp.data.ok) {
 
               $scope.es.valid = true;

--- a/public/directives/expression_directive.js
+++ b/public/directives/expression_directive.js
@@ -34,11 +34,12 @@ Must be inside a function, and start must be adjacent to the argument name
 
 */
 
-app.directive('timelionExpression', function ($compile, $http, $timeout, $rootScope, config) {
+app.directive('timelionExpression', function ($compile, $timeout, $rootScope, config, Private) {
   return {
     restrict: 'A',
     require: 'ngModel',
     link: function ($scope, $elem, $attrs, ngModelCtrl) {
+      var api = Private(require('../services/api'));
 
       var keys = {
         ESC: 27,
@@ -65,7 +66,7 @@ app.directive('timelionExpression', function ($compile, $http, $timeout, $rootSc
         });
 
         $elem.after($compile(template)($scope));
-        $http.get('timelion/functions').then(function (resp) {
+        api.functions().then(function (resp) {
           functionReference.byName = _.indexBy(resp.data, 'name');
           functionReference.list = resp.data;
         });

--- a/public/services/api.js
+++ b/public/services/api.js
@@ -1,0 +1,16 @@
+var chrome = require('ui/chrome');
+
+module.exports = function ($http) {
+
+  function apiMethod(method, name) {
+    return function (opts) {
+      return $http[method](chrome.addBasePath(`/api/timelion/${name}`), opts);
+    };
+  }
+
+  return {
+    run: apiMethod('post', 'run'),
+    functions: apiMethod('get', 'functions'),
+    validateWithEs: apiMethod('get', 'validate/es'),
+  };
+};

--- a/routes/functions.js
+++ b/routes/functions.js
@@ -6,7 +6,7 @@ var _ = require('lodash');
 module.exports = function (server) {
   server.route({
     method: 'GET',
-    path: '/app/timelion/functions',
+    path: '/api/timelion/functions',
     handler: function (request, reply) {
       var functionArray = _.map(functions, function (val, key) {
         // TODO: This won't work on frozen objects, it should be removed when everything is converted to datasources and chainables

--- a/routes/run.js
+++ b/routes/run.js
@@ -11,7 +11,7 @@ module.exports = function (server) {
 
   server.route({
     method: ['POST', 'GET'],
-    path: '/app/timelion/run',
+    path: '/api/timelion/run',
     handler: function (request, reply) {
       var tlConfig = require('../handlers/lib/tl_config.js')({
         server: server,

--- a/routes/validate_es.js
+++ b/routes/validate_es.js
@@ -1,7 +1,7 @@
 module.exports = function (server) {
   server.route({
     method: 'GET',
-    path: '/app/timelion/validate/es',
+    path: '/api/timelion/validate/es',
     handler: function (request, reply) {
       var config = require('../timelion.json');
       var callWithRequest = server.plugins.elasticsearch.callWithRequest;


### PR DESCRIPTION
Requires #57 

Updated API calls to use a new service, `services/api.js`, which creates one place to create/modify/handle urls. For now this service simply wraps `$http` to map a method name to a url and returns the `$http` promise directly.