### PR TITLE
changed default interval to 1m

### DIFF
--- a/public/services/_saved_sheet.js
+++ b/public/services/_saved_sheet.js
@@ -24,7 +24,7 @@ define(function (require) {
           hits: 0,
           description: '',
           timelion_sheet: ['.es(*)'],
-          timelion_interval: '1d',
+          timelion_interval: '1m',
           timelion_other_interval: '1d',
           timelion_chart_height: 275,
           timelion_columns: 3,


### PR DESCRIPTION
The Kibana time picker defaults to 15m with 1d granularity. In my opinion it would make more sense to default the timelion granularity to 1m with a 15m window.