### PR TITLE
#97 - Fix for second y-axis causing the first to lose settings.

### DIFF
--- a/series_functions/yaxis.js
+++ b/series_functions/yaxis.js
@@ -36,7 +36,7 @@ module.exports = new Chainable('yaxis', {
       eachSeries.yaxis = yaxis;
       eachSeries._global = eachSeries._global || {};
 
-      var yaxes = eachSeries._global.yaxes = eachSeries._global.yaxes || [];
+      var yaxes = eachSeries._global.yaxes = eachSeries._global.yaxes || [{},{}];
       var myAxis = yaxes[yaxis - 1] = yaxes[yaxis - 1] || {};
       myAxis.position = position;
       myAxis.min = min == null ? 0 : min;


### PR DESCRIPTION
#97 
Initiialize _global.yaxes as [{},{}] instead of [] , otherwise lodash.merge overwrites the first yaxis with null when a second one is specified - which causes _global.yaxes to be [null,{*options*}]