### PR TITLE
Yaxis units / tickFormatter option

### DIFF
--- a/public/directives/chart_directive.js
+++ b/public/directives/chart_directive.js
@@ -130,7 +130,7 @@ app.directive('chart', function ($compile, $rootScope, timefilter, $timeout, Pri
         if (pos.x < axes.xaxis.min || pos.x > axes.xaxis.max) {
           return;
         }
-        //alert(JSON.stringify(axes));
+
         var i;
         var j;
         var dataset = plot.getData();
@@ -198,8 +198,6 @@ app.directive('chart', function ($compile, $rootScope, timefilter, $timeout, Pri
           }
 
           if (series._global) {
-            //alert(JSON.stringify(options));
-            //alert(JSON.stringify(series._global));
             _.merge(options, series._global);
 
             _.forEach(options.yaxes, function (yaxis) {

--- a/public/directives/chart_directive.js
+++ b/public/directives/chart_directive.js
@@ -21,6 +21,7 @@ app.directive('chart', function ($compile, $rootScope, timefilter, $timeout, Pri
     },
     link: function ($scope, $elem) {
       var timezone = Private(require('plugins/timelion/services/timezone'))();
+      var tickFormatters = require('plugins/timelion/services/tick_formatters')();
 
       $scope.search = $scope.search || _.noop;
 
@@ -129,7 +130,7 @@ app.directive('chart', function ($compile, $rootScope, timefilter, $timeout, Pri
         if (pos.x < axes.xaxis.min || pos.x > axes.xaxis.max) {
           return;
         }
-
+        //alert(JSON.stringify(axes));
         var i;
         var j;
         var dataset = plot.getData();
@@ -153,7 +154,12 @@ app.directive('chart', function ($compile, $rootScope, timefilter, $timeout, Pri
           }
 
           if (y != null) {
-            legendValueNumbers.eq(i).text('(' + y.toFixed(precision) + ')');
+            if (axes.yaxis.options._units !== undefined && tickFormatters[axes.yaxis.options._units[0]] !== undefined) {
+              legendValueNumbers.eq(i).text('(' + tickFormatters[axes.yaxis.options._units[0]](y,axes.yaxis) + ')');
+            }
+            else {
+              legendValueNumbers.eq(i).text('(' + y.toFixed(precision) + ')');
+            }
           } else {
             legendValueNumbers.eq(i).empty();
           }
@@ -197,7 +203,15 @@ app.directive('chart', function ($compile, $rootScope, timefilter, $timeout, Pri
           }
 
           if (series._global) {
+            //alert(JSON.stringify(options));
+            //alert(JSON.stringify(series._global));
             _.merge(options, series._global);
+
+            _.forEach(options.yaxes, function (yaxis) {
+              if (yaxis && yaxis._units !== undefined && tickFormatters[yaxis._units[0]] !== undefined) {
+                yaxis.tickFormatter = tickFormatters[yaxis._units[0]];
+              }
+            });
           }
 
           return series;

--- a/public/directives/chart_directive.js
+++ b/public/directives/chart_directive.js
@@ -154,12 +154,7 @@ app.directive('chart', function ($compile, $rootScope, timefilter, $timeout, Pri
           }
 
           if (y != null) {
-            if (axes.yaxis.options._units !== undefined && tickFormatters[axes.yaxis.options._units[0]] !== undefined) {
-              legendValueNumbers.eq(i).text('(' + tickFormatters[axes.yaxis.options._units[0]](y,axes.yaxis) + ')');
-            }
-            else {
-              legendValueNumbers.eq(i).text('(' + y.toFixed(precision) + ')');
-            }
+            legendValueNumbers.eq(i).text('(' + series.yaxis.tickFormatter(y.toFixed(precision),series.yaxis) + ')');
           } else {
             legendValueNumbers.eq(i).empty();
           }

--- a/public/services/tick_formatters.js
+++ b/public/services/tick_formatters.js
@@ -1,0 +1,57 @@
+define(function (require) {
+
+  return function ticketFormatters() {
+    var formatters =  {
+      'bits': function (val, axis) {
+        var labels = ['b','kb','mb','gb','tb','pb'];
+        var index = 0;
+        while (val > 1000 && index < labels.length) {
+          val /= 1000;
+          index++;
+        }
+        return (Math.round(val * 100) / 100) + labels[index];
+      },
+      'bits/s': function (val, axis) {
+        var labels = ['b/s','kb/s','mb/s','gb/s','tb/s','pb/s'];
+        var index = 0;
+        while (val > 1000 && index < labels.length) {
+          val /= 1000;
+          index++;
+        }
+        return (Math.round(val * 100) / 100) + labels[index];
+      },
+      'bytes': function (val, axis) {
+        var labels = ['B','KB','MB','GB','TB','PB'];
+        var index = 0;
+        while (val > 1024 && index < labels.length) {
+          val /= 1024;
+          index++;
+        }
+        return (Math.round(val * 100) / 100) + labels[index];
+      },
+      'bytes/s': function (val, axis) {
+        var labels = ['B/s','KB/s','MB/s','GB/s','TB/s','PB/s'];
+        var index = 0;
+        while (val > 1024 && index < labels.length) {
+          val /= 1024;
+          index++;
+        }
+        return (Math.round(val * 100) / 100) + labels[index];
+      },
+      'currency': function (val, axis) {
+        var c = 2;
+        var d = '.';
+        var t = ',';
+        var s = val < 0 ? '-' : '';
+        var i = parseInt(val = Math.abs(+val || 0).toFixed(c)) + '';
+        var j = (j = i.length) > 3 ? j % 3 : 0;
+        var p = axis.options._units[1] || '$';
+        return p + ' ' + s + (j ? i.substr(0, j) + t : '') +
+        i.substr(j).replace(/(\d{3})(?=\d)/g, '$1' + t) +
+        (c ? d + Math.abs(val - i).toFixed(c).slice(2) : '');
+      }
+    };
+
+    return formatters;
+  };
+});

--- a/public/services/tick_formatters.js
+++ b/public/services/tick_formatters.js
@@ -49,6 +49,11 @@ define(function (require) {
         return p + ' ' + s + (j ? i.substr(0, j) + t : '') +
         i.substr(j).replace(/(\d{3})(?=\d)/g, '$1' + t) +
         (c ? d + Math.abs(val - i).toFixed(c).slice(2) : '');
+      },
+      'custom': function (val, axis) {
+        var p = axis.options._units[1] || '';
+        var s = axis.options._units[2] || '';
+        return p + val + s;
       }
     };
 

--- a/series_functions/yaxis.js
+++ b/series_functions/yaxis.js
@@ -44,20 +44,17 @@ module.exports = new Chainable('yaxis', {
       eachSeries._global = eachSeries._global || {};
 
       var yaxes = eachSeries._global.yaxes = eachSeries._global.yaxes || [];
-      for (var i = 0 ; i < yaxis-1 ; i++)
-      {
-        yaxes[i] = {};
-      }
+      _.times(yaxis-1,function(idx){
+        yaxes[idx] = {};
+      });
       var myAxis = yaxes[yaxis - 1] = yaxes[yaxis - 1] || {};
       myAxis.position = position;
       myAxis.min = min == null ? 0 : min;
       myAxis.max = max;
 
-      if (units !== null && units !== undefined)
-      {
+      if (units !== null && units !== undefined) {
         var unitTokens = units.split(':');
-        if (tickFormatters[unitTokens[0]] === undefined)
-        {
+        if (tickFormatters[unitTokens[0]] === undefined) {
           throw new Error ('`'+units+'` is not a supported unit type.');
         }
         myAxis._units = unitTokens;

--- a/series_functions/yaxis.js
+++ b/series_functions/yaxis.js
@@ -1,6 +1,9 @@
 var alter = require('../lib/alter.js');
-
+var _ = require('lodash');
 var Chainable = require('../lib/classes/chainable');
+
+var tickFormatters = {'bits':'bits','bits/s':'bits/s','bytes':'bytes','bytes/s':'bytes/s','currency':'currency(:prefix)'}
+
 module.exports = new Chainable('yaxis', {
   args: [
     {
@@ -27,21 +30,34 @@ module.exports = new Chainable('yaxis', {
       types: ['string', 'null'],
       help: 'left or right'
     },
+    {
+      name: 'units',
+      types: ['string', 'null'],
+      help: 'The function to use for formatting y-axis labels. One of: ' + _.values(tickFormatters).join(', ')
+    },
   ],
   help: 'Configures a variety of y-axis options, the most important likely being the ability to add an Nth (eg 2nd) y-axis',
   fn: function yaxisFn(args) {
-    return alter(args, function (eachSeries, yaxis, min, max, position) {
+    return alter(args, function (eachSeries, yaxis, min, max, position, units) {
       yaxis = yaxis || 1;
-
       eachSeries.yaxis = yaxis;
       eachSeries._global = eachSeries._global || {};
 
-      var yaxes = eachSeries._global.yaxes = eachSeries._global.yaxes || [];
+      var yaxes = eachSeries._global.yaxes = eachSeries._global.yaxes || [{},{}];
       var myAxis = yaxes[yaxis - 1] = yaxes[yaxis - 1] || {};
       myAxis.position = position;
       myAxis.min = min == null ? 0 : min;
       myAxis.max = max;
 
+      if (units !== null && units !== undefined)
+      {
+        var unitTokens = units.split(':');
+        if (tickFormatters[unitTokens[0]] === undefined)
+        {
+          throw new Error ('`'+units+'` is not a supported unit type.');
+        }
+        myAxis._units = unitTokens;
+      }
 
       return eachSeries;
     });

--- a/series_functions/yaxis.js
+++ b/series_functions/yaxis.js
@@ -2,7 +2,7 @@ var alter = require('../lib/alter.js');
 var _ = require('lodash');
 var Chainable = require('../lib/classes/chainable');
 
-var tickFormatters = {'bits':'bits','bits/s':'bits/s','bytes':'bytes','bytes/s':'bytes/s','currency':'currency(:prefix)'}
+var tickFormatters = {'bits':'bits','bits/s':'bits/s','bytes':'bytes','bytes/s':'bytes/s','currency':'currency(:prefix)','custom':'custom(:prefix:suffix)'}
 
 module.exports = new Chainable('yaxis', {
   args: [
@@ -43,7 +43,11 @@ module.exports = new Chainable('yaxis', {
       eachSeries.yaxis = yaxis;
       eachSeries._global = eachSeries._global || {};
 
-      var yaxes = eachSeries._global.yaxes = eachSeries._global.yaxes || [{},{}];
+      var yaxes = eachSeries._global.yaxes = eachSeries._global.yaxes || [];
+      for (var i = 0 ; i < yaxis-1 ; i++)
+      {
+        yaxes[i] = {};
+      }
       var myAxis = yaxes[yaxis - 1] = yaxes[yaxis - 1] || {};
       myAxis.position = position;
       myAxis.min = min == null ? 0 : min;


### PR DESCRIPTION
Not sure if its the right way to do this , but needed this functionality , so decided to share back.

Ability to specify one of (bits,bits/s,bytes,bytes/s,currency,custom) unit formatters for y-axis labels.

Example below of : 
.label("series1:bandwidth").yaxis(units=bits/s,max=2000000)
.label("series2:currency").yaxis(2,units=currency:€,max=2000000)
.label("series3:custom").yaxis(3,position=right,units="custom:~ : things",max=2000000)

![image](https://cloud.githubusercontent.com/assets/8225423/14529351/6f199076-0254-11e6-816c-70e7b1e03e63.png)

setLegendNumbers , also updated to use yaxis tickFormatter to format the number

Also includes a fix for #97 
Initializing yaxes as 'var yaxes = eachSeries._global.yaxes = eachSeries._global.yaxes || []';
causes yaxes[0->n-1] to be null/undefined when y-axis n is defined - causing lodash.merge to replace previous configurations with nulls (using defaults).
