### PR TITLE
Axis ticks , x-axis format and label value format

### DIFF
--- a/public/directives/chart_directive.js
+++ b/public/directives/chart_directive.js
@@ -154,7 +154,12 @@ app.directive('chart', function ($compile, $rootScope, timefilter, $timeout, Pri
           }
 
           if (y != null) {
-            legendValueNumbers.eq(i).text('(' + series.yaxis.tickFormatter(y.toFixed(precision),series.yaxis) + ')');
+            var valueLabel = series.valueFormat
+              .replace('%x',pos.x)
+              .replace('%X',series.xaxis.tickFormatter(pos.x,series.xaxis))
+              .replace('%y',y.toFixed(precision))
+              .replace('%Y',series.yaxis.tickFormatter(y.toFixed(precision),series.yaxis));
+            legendValueNumbers.eq(i).text(valueLabel);
           } else {
             legendValueNumbers.eq(i).empty();
           }
@@ -197,6 +202,9 @@ app.directive('chart', function ($compile, $rootScope, timefilter, $timeout, Pri
             series.label = '(hidden) ' + series.label;
           }
 
+          console.log('options:',options);
+          console.log('series:',series);
+        //  _.merge(options, series._);
           if (series._global) {
             _.merge(options, series._global);
 

--- a/public/directives/chart_directive.js
+++ b/public/directives/chart_directive.js
@@ -130,7 +130,7 @@ app.directive('chart', function ($compile, $rootScope, timefilter, $timeout, Pri
         if (pos.x < axes.xaxis.min || pos.x > axes.xaxis.max) {
           return;
         }
-        //alert(JSON.stringify(axes));
+
         var i;
         var j;
         var dataset = plot.getData();
@@ -198,8 +198,6 @@ app.directive('chart', function ($compile, $rootScope, timefilter, $timeout, Pri
           }
 
           if (series._global) {
-            //alert(JSON.stringify(options));
-            //alert(JSON.stringify(series._global));
             _.merge(options, series._global);
 
             _.forEach(options.yaxes, function (yaxis) {

--- a/public/directives/chart_directive.js
+++ b/public/directives/chart_directive.js
@@ -21,6 +21,7 @@ app.directive('chart', function ($compile, $rootScope, timefilter, $timeout, Pri
     },
     link: function ($scope, $elem) {
       var timezone = Private(require('plugins/timelion/services/timezone'))();
+      var tickFormatters = require('plugins/timelion/services/tick_formatters')();
 
       $scope.search = $scope.search || _.noop;
 
@@ -129,7 +130,7 @@ app.directive('chart', function ($compile, $rootScope, timefilter, $timeout, Pri
         if (pos.x < axes.xaxis.min || pos.x > axes.xaxis.max) {
           return;
         }
-
+        //alert(JSON.stringify(axes));
         var i;
         var j;
         var dataset = plot.getData();
@@ -153,7 +154,12 @@ app.directive('chart', function ($compile, $rootScope, timefilter, $timeout, Pri
           }
 
           if (y != null) {
-            legendValueNumbers.eq(i).text('(' + y.toFixed(precision) + ')');
+            if (axes.yaxis.options._units !== undefined && tickFormatters[axes.yaxis.options._units[0]] !== undefined) {
+              legendValueNumbers.eq(i).text('(' + tickFormatters[axes.yaxis.options._units[0]](y,axes.yaxis) + ')');
+            }
+            else {
+              legendValueNumbers.eq(i).text('(' + y.toFixed(precision) + ')');
+            }
           } else {
             legendValueNumbers.eq(i).empty();
           }
@@ -197,7 +203,15 @@ app.directive('chart', function ($compile, $rootScope, timefilter, $timeout, Pri
           }
 
           if (series._global) {
+            //alert(JSON.stringify(options));
+            //alert(JSON.stringify(series._global));
             _.merge(options, series._global);
+
+            _.forEach(options.yaxes, function (yaxis) {
+              if (yaxis && yaxis._units !== undefined && tickFormatters[yaxis._units[0]] !== undefined) {
+                yaxis.tickFormatter = tickFormatters[yaxis._units[0]];
+              }
+            });
           }
 
           return series;

--- a/public/directives/chart_directive.js
+++ b/public/directives/chart_directive.js
@@ -202,9 +202,6 @@ app.directive('chart', function ($compile, $rootScope, timefilter, $timeout, Pri
             series.label = '(hidden) ' + series.label;
           }
 
-          console.log('options:',options);
-          console.log('series:',series);
-        //  _.merge(options, series._);
           if (series._global) {
             _.merge(options, series._global);
 

--- a/public/directives/chart_directive.js
+++ b/public/directives/chart_directive.js
@@ -154,12 +154,7 @@ app.directive('chart', function ($compile, $rootScope, timefilter, $timeout, Pri
           }
 
           if (y != null) {
-            if (axes.yaxis.options._units !== undefined && tickFormatters[axes.yaxis.options._units[0]] !== undefined) {
-              legendValueNumbers.eq(i).text('(' + tickFormatters[axes.yaxis.options._units[0]](y,axes.yaxis) + ')');
-            }
-            else {
-              legendValueNumbers.eq(i).text('(' + y.toFixed(precision) + ')');
-            }
+            legendValueNumbers.eq(i).text('(' + series.yaxis.tickFormatter(y.toFixed(precision),series.yaxis) + ')');
           } else {
             legendValueNumbers.eq(i).empty();
           }

--- a/public/services/tick_formatters.js
+++ b/public/services/tick_formatters.js
@@ -1,0 +1,57 @@
+define(function (require) {
+
+  return function ticketFormatters() {
+    var formatters =  {
+      'bits': function (val, axis) {
+        var labels = ['b','kb','mb','gb','tb','pb'];
+        var index = 0;
+        while (val > 1000 && index < labels.length) {
+          val /= 1000;
+          index++;
+        }
+        return (Math.round(val * 100) / 100) + labels[index];
+      },
+      'bits/s': function (val, axis) {
+        var labels = ['b/s','kb/s','mb/s','gb/s','tb/s','pb/s'];
+        var index = 0;
+        while (val > 1000 && index < labels.length) {
+          val /= 1000;
+          index++;
+        }
+        return (Math.round(val * 100) / 100) + labels[index];
+      },
+      'bytes': function (val, axis) {
+        var labels = ['B','KB','MB','GB','TB','PB'];
+        var index = 0;
+        while (val > 1024 && index < labels.length) {
+          val /= 1024;
+          index++;
+        }
+        return (Math.round(val * 100) / 100) + labels[index];
+      },
+      'bytes/s': function (val, axis) {
+        var labels = ['B/s','KB/s','MB/s','GB/s','TB/s','PB/s'];
+        var index = 0;
+        while (val > 1024 && index < labels.length) {
+          val /= 1024;
+          index++;
+        }
+        return (Math.round(val * 100) / 100) + labels[index];
+      },
+      'currency': function (val, axis) {
+        var c = 2;
+        var d = '.';
+        var t = ',';
+        var s = val < 0 ? '-' : '';
+        var i = parseInt(val = Math.abs(+val || 0).toFixed(c)) + '';
+        var j = (j = i.length) > 3 ? j % 3 : 0;
+        var p = axis.options._units[1] || '$';
+        return p + ' ' + s + (j ? i.substr(0, j) + t : '') +
+        i.substr(j).replace(/(\d{3})(?=\d)/g, '$1' + t) +
+        (c ? d + Math.abs(val - i).toFixed(c).slice(2) : '');
+      }
+    };
+
+    return formatters;
+  };
+});

--- a/public/services/tick_formatters.js
+++ b/public/services/tick_formatters.js
@@ -49,6 +49,11 @@ define(function (require) {
         return p + ' ' + s + (j ? i.substr(0, j) + t : '') +
         i.substr(j).replace(/(\d{3})(?=\d)/g, '$1' + t) +
         (c ? d + Math.abs(val - i).toFixed(c).slice(2) : '');
+      },
+      'custom': function (val, axis) {
+        var p = axis.options._units[1] || '';
+        var s = axis.options._units[2] || '';
+        return p + val + s;
       }
     };
 

--- a/series_functions/label.js
+++ b/series_functions/label.js
@@ -17,17 +17,24 @@ module.exports = new Chainable('label', {
       name: 'regex',
       types: ['string', 'null'],
       help: 'A regex with capture group support'
-    }
+    },
+    {
+      name: 'valueFormat',
+      types: ['string','null'],
+      help: 'Format for displaying values in the label. Use %x and %y for raw x and y values, or %X and %Y for formatted x and y values. default = \'(%Y)\''
+    },
   ],
   help: 'Change the label of the series. Use %s reference the existing label',
   fn:  function labelFn(args) {
     var config = args.byName;
-    return alter(args, function (eachSeries) {
+    return alter(args, function (eachSeries,label,regex,valueFormat) {
       if (config.regex) {
         eachSeries.label = eachSeries.label.replace(new RegExp(config.regex), config.label);
       } else {
         eachSeries.label = config.label;
       }
+
+      eachSeries.valueFormat = valueFormat || '(%Y)';
 
       return eachSeries;
     });

--- a/series_functions/xaxis.js
+++ b/series_functions/xaxis.js
@@ -1,0 +1,47 @@
+var alter = require('../lib/alter.js');
+var _ = require('lodash');
+var Chainable = require('../lib/classes/chainable');
+
+module.exports = new Chainable('xaxis', {
+  args: [
+    {
+      name: 'inputSeries',
+      types: ['seriesList']
+    },
+    {
+      name: 'ticks',
+      types: ['number', 'null'],
+      help: 'Specify the number of y-axis ticks'
+    },
+    {
+      name: 'format',
+      types: ['string', 'null'],
+      help: 'Timestamp format. Use: %a: weekday name, \
+%b: month name, \
+%d: day of month, zero-padded (01-31), \
+%e: day of month, space-padded ( 1-31), \
+%H: hours, 24-hour time, zero-padded (00-23), \
+%I: hours, 12-hour time, zero-padded (01-12), \
+%m: month, zero-padded (01-12), \
+%M: minutes, zero-padded (00-59), \
+%q: quarter (1-4), \
+%S: seconds, zero-padded (00-59), \
+%y: year (two digits), \
+%Y: year (four digits), \
+%p: am/pm, \
+%P: AM/PM (uppercase version of %p), \
+%w: weekday as number (0-6, 0 being Sunday)'
+    },
+  ],
+  help: 'Configures a variety of x-axis options, for instance the timestmap format. If called on more than 1 seriesList the last call will be used.',
+  fn: function yaxisFn(args) {
+    return alter(args, function (eachSeries, ticks, timeformat) {
+      eachSeries._global = eachSeries._global || {};
+      var myAxis = eachSeries._global.xaxis = eachSeries._global.xaxis || {};
+      myAxis.ticks = ticks;
+      myAxis.timeformat = timeformat;
+
+      return eachSeries;
+    });
+  }
+});

--- a/series_functions/xaxis.js
+++ b/series_functions/xaxis.js
@@ -11,7 +11,7 @@ module.exports = new Chainable('xaxis', {
     {
       name: 'ticks',
       types: ['number', 'null'],
-      help: 'Specify the number of y-axis ticks'
+      help: 'Specify the number of x-axis ticks'
     },
     {
       name: 'format',

--- a/series_functions/yaxis.js
+++ b/series_functions/yaxis.js
@@ -44,20 +44,17 @@ module.exports = new Chainable('yaxis', {
       eachSeries._global = eachSeries._global || {};
 
       var yaxes = eachSeries._global.yaxes = eachSeries._global.yaxes || [];
-      for (var i = 0 ; i < yaxis-1 ; i++)
-      {
-        yaxes[i] = {};
-      }
+      _.times(yaxis-1,function(idx){
+        yaxes[idx] = {};
+      });
       var myAxis = yaxes[yaxis - 1] = yaxes[yaxis - 1] || {};
       myAxis.position = position;
       myAxis.min = min == null ? 0 : min;
       myAxis.max = max;
 
-      if (units !== null && units !== undefined)
-      {
+      if (units !== null && units !== undefined) {
         var unitTokens = units.split(':');
-        if (tickFormatters[unitTokens[0]] === undefined)
-        {
+        if (tickFormatters[unitTokens[0]] === undefined) {
           throw new Error ('`'+units+'` is not a supported unit type.');
         }
         myAxis._units = unitTokens;

--- a/series_functions/yaxis.js
+++ b/series_functions/yaxis.js
@@ -31,6 +31,11 @@ module.exports = new Chainable('yaxis', {
       help: 'left or right'
     },
     {
+      name: 'ticks',
+      types: ['number', 'null'],
+      help: 'Specify the number of y-axis ticks'
+    },
+    {
       name: 'units',
       types: ['string', 'null'],
       help: 'The function to use for formatting y-axis labels. One of: ' + _.values(tickFormatters).join(', ')
@@ -38,7 +43,7 @@ module.exports = new Chainable('yaxis', {
   ],
   help: 'Configures a variety of y-axis options, the most important likely being the ability to add an Nth (eg 2nd) y-axis',
   fn: function yaxisFn(args) {
-    return alter(args, function (eachSeries, yaxis, min, max, position, units) {
+    return alter(args, function (eachSeries, yaxis, min, max, position, ticks, units) {
       yaxis = yaxis || 1;
       eachSeries.yaxis = yaxis;
       eachSeries._global = eachSeries._global || {};
@@ -51,6 +56,7 @@ module.exports = new Chainable('yaxis', {
       myAxis.position = position;
       myAxis.min = min == null ? 0 : min;
       myAxis.max = max;
+      myAxis.ticks = ticks;
 
       if (units !== null && units !== undefined) {
         var unitTokens = units.split(':');

--- a/series_functions/yaxis.js
+++ b/series_functions/yaxis.js
@@ -1,6 +1,9 @@
 var alter = require('../lib/alter.js');
-
+var _ = require('lodash');
 var Chainable = require('../lib/classes/chainable');
+
+var tickFormatters = {'bits':'bits','bits/s':'bits/s','bytes':'bytes','bytes/s':'bytes/s','currency':'currency(:prefix)'}
+
 module.exports = new Chainable('yaxis', {
   args: [
     {
@@ -27,21 +30,34 @@ module.exports = new Chainable('yaxis', {
       types: ['string', 'null'],
       help: 'left or right'
     },
+    {
+      name: 'units',
+      types: ['string', 'null'],
+      help: 'The function to use for formatting y-axis labels. One of: ' + _.values(tickFormatters).join(', ')
+    },
   ],
   help: 'Configures a variety of y-axis options, the most important likely being the ability to add an Nth (eg 2nd) y-axis',
   fn: function yaxisFn(args) {
-    return alter(args, function (eachSeries, yaxis, min, max, position) {
+    return alter(args, function (eachSeries, yaxis, min, max, position, units) {
       yaxis = yaxis || 1;
-
       eachSeries.yaxis = yaxis;
       eachSeries._global = eachSeries._global || {};
 
-      var yaxes = eachSeries._global.yaxes = eachSeries._global.yaxes || [];
+      var yaxes = eachSeries._global.yaxes = eachSeries._global.yaxes || [{},{}];
       var myAxis = yaxes[yaxis - 1] = yaxes[yaxis - 1] || {};
       myAxis.position = position;
       myAxis.min = min == null ? 0 : min;
       myAxis.max = max;
 
+      if (units !== null && units !== undefined)
+      {
+        var unitTokens = units.split(':');
+        if (tickFormatters[unitTokens[0]] === undefined)
+        {
+          throw new Error ('`'+units+'` is not a supported unit type.');
+        }
+        myAxis._units = unitTokens;
+      }
 
       return eachSeries;
     });

--- a/series_functions/yaxis.js
+++ b/series_functions/yaxis.js
@@ -2,7 +2,7 @@ var alter = require('../lib/alter.js');
 var _ = require('lodash');
 var Chainable = require('../lib/classes/chainable');
 
-var tickFormatters = {'bits':'bits','bits/s':'bits/s','bytes':'bytes','bytes/s':'bytes/s','currency':'currency(:prefix)'}
+var tickFormatters = {'bits':'bits','bits/s':'bits/s','bytes':'bytes','bytes/s':'bytes/s','currency':'currency(:prefix)','custom':'custom(:prefix:suffix)'}
 
 module.exports = new Chainable('yaxis', {
   args: [
@@ -43,7 +43,11 @@ module.exports = new Chainable('yaxis', {
       eachSeries.yaxis = yaxis;
       eachSeries._global = eachSeries._global || {};
 
-      var yaxes = eachSeries._global.yaxes = eachSeries._global.yaxes || [{},{}];
+      var yaxes = eachSeries._global.yaxes = eachSeries._global.yaxes || [];
+      for (var i = 0 ; i < yaxis-1 ; i++)
+      {
+        yaxes[i] = {};
+      }
       var myAxis = yaxes[yaxis - 1] = yaxes[yaxis - 1] || {};
       myAxis.position = position;
       myAxis.min = min == null ? 0 : min;


### PR DESCRIPTION
#89 

**Note:** Was probably not the right move , but this is based off my 'Yaxis units / tickFormatter option' branch - since I assumed that branch would get pulled anyway :)

Specify valueFormat on series label. %X and %Y for formatted (with axis formatter) values or %x and %y for raw values.
.label("series1:bandwidth",valueFormat='(%Y @ %X)')
.label("series2:bandwidth",valueFormat=': %y : %X')

Specify ticks on yaxis or new xaxis function
.yaxis(ticks=10)
.xaxis(ticks=6)
**Note: ** From the flot docs _'You can specify how many ticks the algorithm aims for by setting "ticks" to a number. The algorithm always tries to generate reasonably round tick values so even if you ask for three ticks, you might get five if that fits better with the rounding.'_

Specify format on the xaxis
.xaxis(format='%a %d, %b %H:%m')

![image](https://cloud.githubusercontent.com/assets/8225423/14637327/da54254c-0630-11e6-9052-036223d9ba9e.png)