### PR TITLE
Update saved_object_registry path to use management

### DIFF
--- a/public/services/saved_sheets.js
+++ b/public/services/saved_sheets.js
@@ -7,7 +7,7 @@ define(function (require) {
 
   // Register this service with the saved object registry so it can be
   // edited by the object editor.
-  require('plugins/kibana/settings/saved_object_registry').register({
+  require('plugins/kibana/management/saved_object_registry').register({
     service: 'savedSheets',
     title: 'sheets'
   });


### PR DESCRIPTION
Settings was changed to management in https://github.com/elastic/kibana/pull/7284.

@tylersmalley can you take a look?

Worth noting that saved sheets aren't being added to the saved objects page, but this issue is present in alpha3 too.